### PR TITLE
Add more precise tag for function/class declaration names

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -47,6 +47,8 @@ export const javascriptLanguage = LezerLanguage.define({
         Label: t.labelName,
         PropertyName: t.propertyName,
         "CallExpression/MemberExpression/PropertyName": t.function(t.propertyName),
+        "FunctionDeclaration/VariableDefinition": t.function(t.definition(t.variableName)),
+        "ClassDeclaration/VariableDefinition": t.definition(t.className),
         PropertyNameDefinition: t.definition(t.propertyName),
         UpdateOp: t.updateOperator,
         LineComment: t.lineComment,


### PR DESCRIPTION
Similar to https://github.com/codemirror/lang-python/commit/162be8f40aebb19334cf229d52e918e626a060ec.

I referenced the tests from [`lezer-parser/javascript`](https://github.com/lezer-parser/javascript/blob/master/test/statement.txt), which has tests for `FunctionDeclaration/VariableDefinition` and `ClassDeclaration/VariableDefinition`.

For the pull request, I am assuming that for purposes of syntax highlighting that `ClassDefinition/VariableName` and `FunctionDefinition/VariableName` in python should give the same output as `ClassDeclaration/VariableDefinition` and `FunctionDeclaration/VariableDefinition` in javascript. 

Even though in javascript there is both `VariableDefinition` and `VariableName`, while in python there's only `VariableName`. This is a slight deviation from codemirror 5 since both function definition names and function parameter names are given the same `cm-def` span.

The alternative for `FunctionDeclaration/VariableDefinition`, instead of 
```js
"FunctionDeclaration/VariableDefinition": t.function(t.definition(t.variableName))
```
can be 
```js
VariableDefinition: t.definition(t.variableName), // already exists
"FunctionDeclaration/VariableDefinition": t.function(t.definition(t.definition(t.variableName)))
```

The drawback for this is if you wanted to highlight function definition names in both python and javascript, you would have to have an additional tag:
```js
  {tag: [tags.function(tags.definition(tags.variableName)), tags.function(tags.definition(tags.definition(tags.variableName)))],
   color: "#6f42c1"},
```



