### PR TITLE
Classify template braces as special braces

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -55,6 +55,7 @@ export const javascriptLanguage = LRLanguage.define({
         Star: t.modifier,
         VariableName: t.variableName,
         "CallExpression/VariableName TaggedTemplateExpression/VariableName": t.function(t.variableName),
+        "TaggedTemplateExpression/templateDollarBrace TaggedTemplateExpression/templateClosingBrace": t.special(t.brace),
         VariableDefinition: t.definition(t.variableName),
         Label: t.labelName,
         PropertyName: t.propertyName,


### PR DESCRIPTION
Hi @marijnh ! 👋

Not sure if I did this correctly (and also not sure whether you want to accept this change), but I thought I'd give it a try to classify template braces (including the starting dollar brace) as a "special brace".

I did this by looking at the Lezer parser grammar for JavaScript and finding that there was this `templateDollarBrace` and `templateClosingBrace`.

https://github.com/lezer-parser/javascript/blob/afdc2da19789486e8f42c966a2daddd54907614c/src/javascript.grammar#L442

However, I'm not sure if those are accessible how I have it in this PR.

If you are amenable to this change, but it is not working, feel free to let me know and I can fix it (I may need a bit of a hint how).

---

This is to improve the communication to developers that the dollar and braces are not a string literal part of the template string (and also improve the color contrast):

Prism.js / VS Code:

![Screen Shot 2022-01-15 at 18 09 00](https://user-images.githubusercontent.com/1935696/149630936-55df0d3a-27e3-4778-8da6-2de90f73a7f4.png)

CodeMirror:

![Screen Shot 2022-01-15 at 18 09 38](https://user-images.githubusercontent.com/1935696/149630944-709c9179-5a1d-4986-88d8-52ff092dcaf1.png)