### PR TITLE
Add tag closing functionality for JSX

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -27,6 +27,7 @@ to communication around the project.
 @typescriptLanguage
 @jsxLanguage
 @tsxLanguage
+@autoCloseTags
 
 @snippets
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export {javascriptLanguage, typescriptLanguage, jsxLanguage, tsxLanguage, javascript} from "./javascript"
+export {javascriptLanguage, typescriptLanguage, jsxLanguage, tsxLanguage, autoCloseTags, javascript} from "./javascript"
 export {snippets} from "./snippets"
 export {esLint} from "./eslint"


### PR DESCRIPTION
FEATURE: The new `autoCloseTags` extension (included by default in the `javascript` language extension when `jsx` is configured) finishes JSX closing tags when you type a `>` or `/` character.

Closes https://github.com/codemirror/codemirror.next/issues/779