### PR TITLE
docs: add eslint-linter-browserify example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ class, and <code>config</code> an optional ESLint configuration. The return
 value of this function can be passed to <a href="https://codemirror.net/docs/ref/#lint.linter"><code>linter</code></a>
 to create a JavaScript linting extension.</p>
 <p>Note that ESLint targets node, and is tricky to run in the
-browser. The <a href="https://github.com/mysticatea/eslint4b">eslint4b</a>
-and
-<a href="https://github.com/marijnh/eslint4b-prebuilt/">eslint4b-prebuilt</a>
-packages may help with that.</p>
+browser. The <a href="https://github.com/UziTech/eslint-linter-browserify">eslint-linter-browserify</a>
+package may help with that (see <a href="https://github.com/UziTech/eslint-linter-browserify/blob/master/example/script.js">example</a>).</p>
 </dd>
 </dl>


### PR DESCRIPTION
Update docs to show example for eslint using [eslint-linter-browserify](https://www.npmjs.com/package/eslint-linter-browserify).

eslint4b hasn't been updated in a couple years and doesn't provide eslint v8. [eslint-linter-browserify](https://github.com/UziTech/eslint-linter-browserify) is automated to release new version when eslint releases new versions and it was recently updated to work with CodeMirror v6.

see [this example](https://github.com/UziTech/eslint-linter-browserify/blob/master/example/script.js) for simple usage.