### PR TITLE
Fix JSX fragment autoclose tag logic

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -111,7 +111,7 @@ export const autoCloseTags = EditorView.inputHandler.of((view, from, to, text) =
     let {head} = range, around = syntaxTree(state).resolveInner(head, -1), name
     if (around.name == "JSXStartTag") around = around.parent!
     if (text == ">" && around.name == "JSXFragmentTag") {
-      return {range: EditorSelection.cursor(head + 1), changes: {from: head, insert: `><>`}}
+      return {range: EditorSelection.cursor(head + 1), changes: {from: head, insert: `></>`}}
     } else if (text == "/" && around.name == "JSXFragmentTag") {
       let empty = around.parent, base = empty?.parent
       if (empty!.from == head - 1 && base!.lastChild?.name != "JSXEndTag" &&


### PR DESCRIPTION
Looks like we're using the wrong close tag for JSX fragments in the autoclose extension as it should be `</>` instead of `<>` (see [docs](https://reactjs.org/docs/fragments.html#short-syntax)).

Seems I just missed this when I first implemented this extension in https://github.com/codemirror/lang-javascript/pull/4.