### PR TITLE
Allow folding typescript interface and object type alias

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -41,7 +41,7 @@ export const javascriptLanguage = LRLanguage.define({
         }
       }),
       foldNodeProp.add({
-        "Block ClassBody SwitchBody EnumBody ObjectExpression ArrayExpression": foldInside,
+        "Block ClassBody SwitchBody EnumBody ObjectExpression ArrayExpression ObjectType": foldInside,
         BlockComment(tree) { return {from: tree.from + 2, to: tree.to - 2} }
       })
     ]


### PR DESCRIPTION
Folding doesn't work for 

```
interface X {

}

// or
type X = {

}
```

This PR adds the `ObjectType` type to the `foldNodeProp` alongside other block elements.