### PR TITLE
fix arrow functions auto-closing JSX tag

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -94,6 +94,7 @@ export function javascript(config: {jsx?: boolean, typescript?: boolean} = {}) {
 
 function findOpenTag(node: SyntaxNode) {
   for (;;) {
+    if (node.name == "ArrowFunction") return null
     if (node.name == "JSXOpenTag" || node.name == "JSXSelfClosingTag" || node.name == "JSXFragmentTag") return node
     if (!node.parent) return null
     node = node.parent


### PR DESCRIPTION
Currently writing:
```jsx
<button onClick={()= } />
```
and typing `>` to the right of `=` incorrectly auto-closes the tag to:
```jsx
<button onClick={()=></button> } />
```
this PR fixes this behavior.