### PR TITLE
add TypeScript keywords + future reserved keywords

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -74,7 +74,7 @@ export const tsxLanguage = javascriptLanguage.configure({
   props: [sublanguageProp.add(n => n.isTop ? [jsxSublanguage] : undefined)]
 }, "typescript")
 
-const keywords = "break case const continue default delete export extends false finally in instanceof let new return static super switch this throw true typeof var yield".split(" ").map(kw => ({label: kw, type: "keyword"}))
+const keywords = "break case const continue default delete enum export extends false finally implements in instanceof interface let new package private protected public return static super switch this throw true type typeof var yield".split(" ").map(kw => ({label: kw, type: "keyword"}))
 
 /// JavaScript support. Includes [snippet](#lang-javascript.snippets)
 /// completion.


### PR DESCRIPTION
add the following keywords:
- `enum`
- `implements`
- `interface`
- `package`
- `private`
- `protected`
- `public`
- `type`

@marijnh I think that ideally some should be TypeScript only, also some should be scoped to the strict mode [per the spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#future_reserved_words), but that would require greater changes.  In the meantime I think that these should be added sooner rather than later as currently they can't be styled.
