### PR TITLE
Add `satisfies` keyword to `typescriptKeywords`

### DIFF
--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -77,7 +77,7 @@ export const tsxLanguage = javascriptLanguage.configure({
 let kwCompletion = (name: string) => ({label: name, type: "keyword"})
 
 const keywords = "break case const continue default delete export extends false finally in instanceof let new return static super switch this throw true typeof var yield".split(" ").map(kwCompletion)
-const typescriptKeywords = keywords.concat(["declare", "implements", "private", "protected", "public"].map(kwCompletion))
+const typescriptKeywords = keywords.concat(["declare", "implements", "private", "protected", "public", "satisfies"].map(kwCompletion))
 
 /// JavaScript support. Includes [snippet](#lang-javascript.snippets)
 /// completion.


### PR DESCRIPTION
I added support for one of my favourite TypeScript features: the `satisfies` keyword (well, _operator_, according to the TS people). It was added in [TypeScript 4.9](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator).