### PR TITLE
Prevent autocomplete when in JSX

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -68,6 +68,7 @@ export const dontComplete = [
   "VariableDefinition", "TypeDefinition", "Label",
   "PropertyDefinition", "PropertyName",
   "PrivatePropertyDefinition", "PrivatePropertyName",
+  "JSXText", "JSXAttributeValue", "JSXOpenTag", "JSXCloseTag", "JSXSelfClosingTag",
   ".", "?."
 ]
 


### PR DESCRIPTION
Hi there :wave:

This contribution adds `"JSXText", "JSXAttributeValue", "JSXOpenTag", "JSXCloseTag", "JSXSelfClosingTag"` to `dontComplete` to ensure that we do not show JavaScript completions when in a JSX node.

[Minimal Repro - Try Codemirror](https://codemirror.net/try/?c=aW1wb3J0IHtiYXNpY1NldHVwLCBFZGl0b3JWaWV3fSBmcm9tICJjb2RlbWlycm9yIgppbXBvcnQge2phdmFzY3JpcHR9IGZyb20gIkBjb2RlbWlycm9yL2xhbmctamF2YXNjcmlwdCIKCm5ldyBFZGl0b3JWaWV3KHsKICBkb2M6ICJjb25zb2xlLmxvZygnaGVsbG8nKVxuIiwKICBleHRlbnNpb25zOiBbYmFzaWNTZXR1cCwgamF2YXNjcmlwdCh7anN4OiB0cnVlfSldLAogIHBhcmVudDogZG9jdW1lbnQuYm9keQp9KQo=)

## Examples

```jsx
export function MyComponent () {
  return <p>func|
/*              ^ cursor
 * I'm inside of a JSXText node, but it would
 * show `function` as a completion, which is
 * not very useful inside of a `JSXText`
 */
```

```jsx
export function MyComponent () {
  return <p className="func|
/*                         ^ cursor
 * I'm inside of a JSXAttributeValue node,
 * but it would show `function` as a
 * completion, which is not very useful
 * inside of a `JSXAttributeValue`
 */
```

## Screenshots

![CleanShot 2024-11-23 at 10 18 17@2x](https://github.com/user-attachments/assets/8f68e89c-5cf0-4db7-b750-08ff15aa8d67)

![CleanShot 2024-11-23 at 10 17 16@2x](https://github.com/user-attachments/assets/f7c0f112-067d-488b-b7ae-418b1fabf35f)