### PR TITLE
Fix error when meta.docs is undefined

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -23,7 +23,7 @@ export function esLint(eslint: any, config?: any) {
       rules: {}
     }
     eslint.getRules().forEach((desc: any, name: string) => {
-      if (desc.meta.docs.recommended) config.rules[name] = 2
+      if (desc.meta.docs?.recommended) config.rules[name] = 2
     })
   }
 


### PR DESCRIPTION
hello. I would like to fix an issue where an error occurs when ESLint Meta docs is undefined. I get errorㄴ when using some plugin rules.

Note that docs is optional in eslint's meta data.

https://github.com/eslint/eslint/blob/17cb9586a706e75adee09b2388deea77a6ca8f14/lib/types/index.d.ts#L755-L767