### PR TITLE
Fix missing inherited getters in enumeratePropertyCompletions

### DIFF
--- a/src/complete.ts
+++ b/src/complete.ts
@@ -134,13 +134,14 @@ export function completionPath(context: CompletionContext): {path: readonly stri
 }
 
 function enumeratePropertyCompletions(obj: any, top: boolean): readonly Completion[] {
+  let originalObj = obj
   let options: Completion[] = [], seen: Set<string> = new Set
   for (let depth = 0;; depth++) {
     for (let name of (Object.getOwnPropertyNames || Object.keys)(obj)) {
       if (!/^[a-zA-Z_$\xaa-\uffdc][\w$\xaa-\uffdc]*$/.test(name) || seen.has(name)) continue
       seen.add(name)
       let value
-      try { value = obj[name] }
+      try { value = originalObj[name] }
       catch(_) { continue }
       options.push({
         label: name,


### PR DESCRIPTION
Take this example:
```js
class Base {
  a = { b: 10 }
  get foo() { return this.a.b }
}

class ChildClass extends Base {}

const scope = { test: new ChildClass() }
```

When using `scopeCompletionSource(scope)` as an extension, the autocompletion of `test.` will list `a` but not the inherited getter `foo`. This is because when calling `obj[name]` while iterating over the properties of `Object.getPrototypeOf(obj)`, `this` refers to the prototype and not the instance. So `this.a` returns `undefined` and thus `this.a.b` throws an error.

Hopefully the issue becomes clear by just looking at the fix.